### PR TITLE
Bump terraform to v1.3 for dns-firewall module

### DIFF
--- a/examples/dns-firewall-full/main.tf
+++ b/examples/dns-firewall-full/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+
+###################################################
+# DNS Firewall
+###################################################
+
+module "dns_firewall" {
+  source = "../../modules/dns-firewall"
+  # source  = "tedilabs/firewall/aws//modules/dns-firewall"
+  # version = "~> 0.1.0"
+
+  vpc_id            = data.aws_vpc.default.id
+  fail_open_enabled = true
+
+  rule_groups = []
+
+  tags = {
+    "project" = "terraform-aws-firewall-examples"
+  }
+}

--- a/examples/dns-firewall-full/outputs.tf
+++ b/examples/dns-firewall-full/outputs.tf
@@ -1,0 +1,3 @@
+output "dns_firewall" {
+  value = module.dns_firewall
+}

--- a/examples/dns-firewall-full/versions.tf
+++ b/examples/dns-firewall-full/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/dns-firewall/README.md
+++ b/modules/dns-firewall/README.md
@@ -10,24 +10,25 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.14.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.33.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_route53_resolver_firewall_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_config) | resource |
 | [aws_route53_resolver_firewall_rule_group_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule_group_association) | resource |
 
@@ -41,7 +42,7 @@ No modules.
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
-| <a name="input_rule_groups"></a> [rule\_groups](#input\_rule\_groups) | (Optional) A list of rule groups associated with the firewall. Each value of `rule_group` block as defined below.<br>    (Required) `id` - The ID of the firewall rule group.<br>    (Required) `priority` - The setting that determines the processing order of the rule group among the rule groups that you associate with the specified VPC. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting.<br>    (Optional) `mutation_protection_enabled` - If enabled, this setting disallows modification or removal of the association, to help prevent against accidentally altering DNS firewall protections. | `any` | `[]` | no |
+| <a name="input_rule_groups"></a> [rule\_groups](#input\_rule\_groups) | (Optional) A list of rule groups associated with the firewall. Each value of `rule_group` block as defined below.<br>    (Required) `id` - The ID of the firewall rule group.<br>    (Required) `priority` - The setting that determines the processing order of the rule group among the rule groups that you associate with the specified VPC. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting.<br>    (Optional) `mutation_protection_enabled` - If enabled, this setting disallows modification or removal of the association, to help prevent against accidentally altering DNS firewall protections. | <pre>list(object({<br>    id       = string<br>    priority = number<br><br>    mutation_protection_enabled = optional(bool, false)<br>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/dns-firewall/main.tf
+++ b/modules/dns-firewall/main.tf
@@ -42,7 +42,7 @@ resource "aws_route53_resolver_firewall_rule_group_association" "this" {
   priority               = each.key
   firewall_rule_group_id = each.value.id
 
-  mutation_protection = try(each.value.mutation_protection_enabled, false) ? "ENABLED" : "DISABLED"
+  mutation_protection = each.value.mutation_protection_enabled ? "ENABLED" : "DISABLED"
 
   tags = merge(
     {

--- a/modules/dns-firewall/resource-group.tf
+++ b/modules/dns-firewall/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/dns-firewall/variables.tf
+++ b/modules/dns-firewall/variables.tf
@@ -1,12 +1,14 @@
 variable "vpc_id" {
   description = "(Required) The ID of the VPC which the firewall belongs to."
   type        = string
+  nullable    = false
 }
 
 variable "fail_open_enabled" {
   description = "(Optional) Determines how Route 53 Resolver handles queries during failures, for example when all traffic that is sent to DNS Firewall fails to receive a reply. By default, fail open is disabled, which means the failure mode is closed. This approach favors security over availability. DNS Firewall blocks queries that it is unable to evaluate properly. If you enable this option, the failure mode is open. This approach favors availability over security. DNS Firewall allows queries to proceed if it is unable to properly evaluate them."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "rule_groups" {
@@ -16,8 +18,14 @@ variable "rule_groups" {
     (Required) `priority` - The setting that determines the processing order of the rule group among the rule groups that you associate with the specified VPC. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting.
     (Optional) `mutation_protection_enabled` - If enabled, this setting disallows modification or removal of the association, to help prevent against accidentally altering DNS firewall protections.
   EOF
-  type        = any
-  default     = []
+  type = list(object({
+    id       = string
+    priority = number
+
+    mutation_protection_enabled = optional(bool, false)
+  }))
+  default  = []
+  nullable = false
 
   validation {
     condition = alltrue([
@@ -35,12 +43,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -52,16 +62,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/dns-firewall/versions.tf
+++ b/modules/dns-firewall/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Background

- Refactor `dns-firewall` module using `optional` feature of Terraform v1.3 
- Add example code `dns-firewall-full`