### PR TITLE
Bump terraform to v1.3 for dns-firewall-rule-group module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -3,5 +3,7 @@
 - modules/dns-firewall-domain-list/**/*
 ":floppy_disk: dns-firewall-rule-group":
 - modules/dns-firewall-rule-group/**/*
+":floppy_disk: dns-firewall":
+- modules/dns-firewall/**/*
 ":floppy_disk: network-firewall":
 - modules/network-firewall/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -47,5 +47,8 @@
   description: "This issue or pull request is related to dns-firewall-rule-group module."
   name: ":floppy_disk: dns-firewall-rule-group"
 - color: "fbca04"
+  description: "This issue or pull request is related to dns-firewall module."
+  name: ":floppy_disk: dns-firewall"
+- color: "fbca04"
   description: "This issue or pull request is related to network-firewall module."
   name: ":floppy_disk: network-firewall"

--- a/modules/dns-firewall-rule-group/README.md
+++ b/modules/dns-firewall-rule-group/README.md
@@ -10,24 +10,25 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.14.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.33.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_route53_resolver_firewall_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule) | resource |
 | [aws_route53_resolver_firewall_rule_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule_group) | resource |
 
@@ -41,7 +42,7 @@ No modules.
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
-| <a name="input_rules"></a> [rules](#input\_rules) | (Optional) The rules that you define for the firewall rule group determine the filtering behavior. Each rule consists of a priority, a domain list, and action. Each item of `rules` block as defined below.<br>    (Required) `priority` - Determine the processing order of the rule in the rule group. DNS Firewall processes the rules in a rule group by order of priority, starting from the lowest priority.<br>    (Required) `name` - A name that lets you identify the rule.<br>    (Optional) `description` - The description of the rule.<br>    (Required) `domain_list` - The ID of the domain list that you want to use in the rule.<br>    (Required) `action` - The action that DNS Firewall should take on a DNS query when it matches one of the domains in the rule's domain list. Valid values are `ALLOW`, `BLOCK`, `ALERT`.<br>    (Optional) `action_parameters` - The configuration block for the parameters of the rule action. Only required with `BLOCK` action. `action_parameters` block as defined below.<br>      (Required) `response` - The way that you want DNS Firewall to block the request. Valid values are `NODATA`, `NXDOMAIN`, `OVERRIDE`. `NODATA` indicates that this query was successful, but there is no response available for the query. `NXDOMAIN` indicates that the domain name that's in the query doesn't exist. `OVERRIDE` provides a custom override response to the query.<br>      (Optional) `override` - The configuration for a custom override response to the query. Only required with `OVERRIDE` block response.<br>        (Required) `type` - The DNS record's type. This determines the format of the record value that you provided in BlockOverrideDomain. Value values are `CNAME`.<br>        (Required) `value` - The custom DNS record to send back in response to the query.<br>        (Required) `ttl` - The recommended amount of time, in seconds, for the DNS resolver or web browser to cache the provided override record. Minimum value of `0`. Maximum value of `604800`. | `any` | `[]` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | (Optional) The rules that you define for the firewall rule group determine the filtering behavior. Each rule consists of a priority, a domain list, and action. Each item of `rules` block as defined below.<br>    (Required) `priority` - Determine the processing order of the rule in the rule group. DNS Firewall processes the rules in a rule group by order of priority, starting from the lowest priority.<br>    (Required) `name` - A name that lets you identify the rule.<br>    (Optional) `description` - The description of the rule.<br>    (Required) `domain_list` - The ID of the domain list that you want to use in the rule.<br>    (Required) `action` - The action that DNS Firewall should take on a DNS query when it matches one of the domains in the rule's domain list. Valid values are `ALLOW`, `BLOCK`, `ALERT`.<br>    (Optional) `action_parameters` - The configuration block for the parameters of the rule action. Only required with `BLOCK` action. `action_parameters` block as defined below.<br>      (Required) `response` - The way that you want DNS Firewall to block the request. Valid values are `NODATA`, `NXDOMAIN`, `OVERRIDE`. `NODATA` indicates that this query was successful, but there is no response available for the query. `NXDOMAIN` indicates that the domain name that's in the query doesn't exist. `OVERRIDE` provides a custom override response to the query.<br>      (Optional) `override` - The configuration for a custom override response to the query. Only required with `OVERRIDE` block response.<br>        (Required) `type` - The DNS record's type. This determines the format of the record value that you provided in BlockOverrideDomain. Value values are `CNAME`.<br>        (Required) `value` - The custom DNS record to send back in response to the query.<br>        (Required) `ttl` - The recommended amount of time, in seconds, for the DNS resolver or web browser to cache the provided override record. Minimum value of `0`. Maximum value of `604800`. | <pre>list(object({<br>    priority    = number<br>    name        = string<br>    description = optional(string, "Managed by Terraform.")<br>    domain_list = string<br><br>    action = string<br>    action_parameters = optional(object({<br>      response = optional(string, null)<br>      override = optional(object({<br>        type  = string<br>        value = string<br>        ttl   = number<br>      }), null)<br>    }), null)<br>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/dns-firewall-rule-group/main.tf
+++ b/modules/dns-firewall-rule-group/main.tf
@@ -53,16 +53,20 @@ resource "aws_route53_resolver_firewall_rule" "this" {
   action = each.value.action
   block_response = (each.value.action == "BLOCK"
     ? each.value.action_parameters.response
-  : null)
-  block_override_domain = (each.value.action_parameters.response == "OVERRIDE"
+    : null
+  )
+  block_override_domain = (try(each.value.action_parameters.response, null) == "OVERRIDE"
     ? each.value.action_parameters.override.value
-  : null)
-  block_override_dns_type = (each.value.action_parameters.response == "OVERRIDE"
+    : null
+  )
+  block_override_dns_type = (try(each.value.action_parameters.response, null) == "OVERRIDE"
     ? each.value.action_parameters.override.type
-  : null)
+    : null
+  )
 
-  block_override_ttl = (each.value.action_parameters.response == "OVERRIDE"
+  block_override_ttl = (try(each.value.action_parameters.response, null) == "OVERRIDE"
     ? each.value.action_parameters.override.ttl
-  : null)
+    : null
+  )
 
 }

--- a/modules/dns-firewall-rule-group/resource-group.tf
+++ b/modules/dns-firewall-rule-group/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/dns-firewall-rule-group/variables.tf
+++ b/modules/dns-firewall-rule-group/variables.tf
@@ -7,6 +7,7 @@ variable "description" {
   description = "(Optional) The description of the firewall rule group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }
 
 variable "rules" {
@@ -24,8 +25,24 @@ variable "rules" {
         (Required) `value` - The custom DNS record to send back in response to the query.
         (Required) `ttl` - The recommended amount of time, in seconds, for the DNS resolver or web browser to cache the provided override record. Minimum value of `0`. Maximum value of `604800`.
   EOF
-  type        = any
-  default     = []
+  type = list(object({
+    priority    = number
+    name        = string
+    description = optional(string, "Managed by Terraform.")
+    domain_list = string
+
+    action = string
+    action_parameters = optional(object({
+      response = optional(string, null)
+      override = optional(object({
+        type  = string
+        value = string
+        ttl   = number
+      }), null)
+    }), null)
+  }))
+  default  = []
+  nullable = false
 
   validation {
     condition = alltrue([
@@ -72,12 +89,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -89,16 +108,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/dns-firewall-rule-group/versions.tf
+++ b/modules/dns-firewall-rule-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Background

- Refactor `dns-firewall-rule-group` module using `optional` feature of Terraform v1.3 