### PR TITLE
Bump terraform to v1.3 for dns-firewall-domain-list module

### DIFF
--- a/examples/dns-firewall-full/main.tf
+++ b/examples/dns-firewall-full/main.tf
@@ -8,10 +8,65 @@ data "aws_vpc" "default" {
 
 
 ###################################################
+# DNS Firewall Domain List
+###################################################
+
+module "domain_list" {
+  source = "../../modules/dns-firewall-domain-list"
+  # source  = "tedilabs/firewall/aws//modules/dns-firewall-domain-list"
+  # version = "~> 0.1.0"
+
+  name = "example"
+  domains = [
+    "example1.mycompany.com.",
+    "example2.mycompany.com.",
+    "example3.mycompany.com.",
+  ]
+
+  tags = {
+    "project" = "terraform-aws-firewall-examples"
+  }
+}
+
+
+###################################################
+# DNS Firewall Rule Group
+###################################################
+
+module "rule_group" {
+  source = "../../modules/dns-firewall-rule-group"
+  # source  = "tedilabs/firewall/aws//modules/dns-firewall-rule-group"
+  # version = "~> 0.1.0"
+
+  name = "block-blacklist"
+  rules = [
+    {
+      priority    = 10
+      name        = "block-example"
+      domain_list = module.domain_list.id
+      action      = "BLOCK"
+      action_parameters = {
+        response = "OVERRIDE"
+        override = {
+          type  = "CNAME"
+          value = "404.mycompany.com."
+          ttl   = 60
+        }
+      }
+    },
+  ]
+
+  tags = {
+    "project" = "terraform-aws-firewall-examples"
+  }
+}
+
+
+###################################################
 # DNS Firewall
 ###################################################
 
-module "dns_firewall" {
+module "firewall" {
   source = "../../modules/dns-firewall"
   # source  = "tedilabs/firewall/aws//modules/dns-firewall"
   # version = "~> 0.1.0"

--- a/examples/dns-firewall-full/outputs.tf
+++ b/examples/dns-firewall-full/outputs.tf
@@ -1,3 +1,11 @@
-output "dns_firewall" {
-  value = module.dns_firewall
+output "domain_list" {
+  value = module.domain_list
+}
+
+output "rule_group" {
+  value = module.rule_group
+}
+
+output "firewall" {
+  value = module.firewall
 }

--- a/modules/dns-firewall-domain-list/README.md
+++ b/modules/dns-firewall-domain-list/README.md
@@ -9,24 +9,25 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.14.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.33.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_route53_resolver_firewall_domain_list.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_domain_list) | resource |
 
 ## Inputs

--- a/modules/dns-firewall-domain-list/resource-group.tf
+++ b/modules/dns-firewall-domain-list/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/dns-firewall-domain-list/variables.tf
+++ b/modules/dns-firewall-domain-list/variables.tf
@@ -7,6 +7,7 @@ variable "domains" {
   description = "(Optional) A list of domains for the firewall domain list."
   type        = list(string)
   default     = []
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -21,12 +22,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -38,16 +41,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/dns-firewall-domain-list/versions.tf
+++ b/modules/dns-firewall-domain-list/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Background

- Refactor `dns-firewall-domain-list` module using `optional` feature of Terraform v1.3 
- Update example code `dns-firewall-full`