### PR TITLE
Support ram sharing of dns-firewall-rule-group module

### DIFF
--- a/modules/dns-firewall-rule-group/README.md
+++ b/modules/dns-firewall-rule-group/README.md
@@ -17,13 +17,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.33.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.46.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
+| <a name="module_share"></a> [share](#module\_share) | tedilabs/account/aws//modules/ram-share | ~> 0.23.0 |
 
 ## Resources
 
@@ -43,6 +44,7 @@ This module creates following resources.
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
 | <a name="input_rules"></a> [rules](#input\_rules) | (Optional) The rules that you define for the firewall rule group determine the filtering behavior. Each rule consists of a priority, a domain list, and action. Each item of `rules` block as defined below.<br>    (Required) `priority` - Determine the processing order of the rule in the rule group. DNS Firewall processes the rules in a rule group by order of priority, starting from the lowest priority.<br>    (Required) `name` - A name that lets you identify the rule.<br>    (Optional) `description` - The description of the rule.<br>    (Required) `domain_list` - The ID of the domain list that you want to use in the rule.<br>    (Required) `action` - The action that DNS Firewall should take on a DNS query when it matches one of the domains in the rule's domain list. Valid values are `ALLOW`, `BLOCK`, `ALERT`.<br>    (Optional) `action_parameters` - The configuration block for the parameters of the rule action. Only required with `BLOCK` action. `action_parameters` block as defined below.<br>      (Required) `response` - The way that you want DNS Firewall to block the request. Valid values are `NODATA`, `NXDOMAIN`, `OVERRIDE`. `NODATA` indicates that this query was successful, but there is no response available for the query. `NXDOMAIN` indicates that the domain name that's in the query doesn't exist. `OVERRIDE` provides a custom override response to the query.<br>      (Optional) `override` - The configuration for a custom override response to the query. Only required with `OVERRIDE` block response.<br>        (Required) `type` - The DNS record's type. This determines the format of the record value that you provided in BlockOverrideDomain. Value values are `CNAME`.<br>        (Required) `value` - The custom DNS record to send back in response to the query.<br>        (Required) `ttl` - The recommended amount of time, in seconds, for the DNS resolver or web browser to cache the provided override record. Minimum value of `0`. Maximum value of `604800`. | <pre>list(object({<br>    priority    = number<br>    name        = string<br>    description = optional(string, "Managed by Terraform.")<br>    domain_list = string<br><br>    action = string<br>    action_parameters = optional(object({<br>      response = optional(string, null)<br>      override = optional(object({<br>        type  = string<br>        value = string<br>        ttl   = number<br>      }), null)<br>    }), null)<br>  }))</pre> | `[]` | no |
+| <a name="input_shares"></a> [shares](#input\_shares) | (Optional) A list of resource shares via RAM (Resource Access Manager). | <pre>list(object({<br>    name = optional(string)<br><br>    permissions = optional(set(string), ["AWSRAMDefaultPermissionResolverFirewallRuleGroup"])<br><br>    external_principals_allowed = optional(bool, false)<br>    principals                  = optional(set(string), [])<br><br>    tags = optional(map(string), {})<br>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -54,5 +56,5 @@ This module creates following resources.
 | <a name="output_name"></a> [name](#output\_name) | The name of the firewall rule group. |
 | <a name="output_owner_id"></a> [owner\_id](#output\_owner\_id) | The AWS Account ID for the account that created the rule group. |
 | <a name="output_rules"></a> [rules](#output\_rules) | The rules of the firewall rule group. |
-| <a name="output_share_status"></a> [share\_status](#output\_share\_status) | Whether the rule group is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Valid values: `NOT_SHARED`, `SHARED_BY_ME`, `SHARED_WITH_ME`. |
+| <a name="output_sharing"></a> [sharing](#output\_sharing) | The configuration for sharing of the Route53 Resolver DNS Firewall Rule Group.<br>    `status` - An indication of whether the rule group is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`.<br>    `shares` - The list of resource shares via RAM (Resource Access Manager). |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/dns-firewall-rule-group/outputs.tf
+++ b/modules/dns-firewall-rule-group/outputs.tf
@@ -13,11 +13,6 @@ output "owner_id" {
   value       = aws_route53_resolver_firewall_rule_group.this.owner_id
 }
 
-output "share_status" {
-  description = "Whether the rule group is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Valid values: `NOT_SHARED`, `SHARED_BY_ME`, `SHARED_WITH_ME`."
-  value       = aws_route53_resolver_firewall_rule_group.this.share_status
-}
-
 output "name" {
   description = "The name of the firewall rule group."
   value       = aws_route53_resolver_firewall_rule_group.this.name
@@ -50,5 +45,17 @@ output "rules" {
         }
       }[rule.action], {})
     }
+  }
+}
+
+output "sharing" {
+  description = <<EOF
+  The configuration for sharing of the Route53 Resolver DNS Firewall Rule Group.
+    `status` - An indication of whether the rule group is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`.
+    `shares` - The list of resource shares via RAM (Resource Access Manager).
+  EOF
+  value = {
+    status = aws_route53_resolver_firewall_rule_group.this.share_status
+    shares = module.share
   }
 }

--- a/modules/dns-firewall-rule-group/ram-share.tf
+++ b/modules/dns-firewall-rule-group/ram-share.tf
@@ -1,0 +1,32 @@
+###################################################
+# Resource Sharing by RAM (Resource Access Manager)
+###################################################
+
+module "share" {
+  source  = "tedilabs/account/aws//modules/ram-share"
+  version = "~> 0.23.0"
+
+  for_each = {
+    for share in var.shares :
+    share.name => share
+  }
+
+  name = "route53-resolver.dns-firewall-rule-group.${var.name}.${each.key}"
+
+  resources = [
+    aws_route53_resolver_firewall_rule_group.this.arn,
+  ]
+  permissions = each.value.permissions
+
+  external_principals_allowed = each.value.external_principals_allowed
+  principals                  = each.value.principals
+
+  resource_group_enabled = false
+  module_tags_enabled    = false
+
+  tags = merge(
+    local.module_tags,
+    var.tags,
+    each.value.tags,
+  )
+}

--- a/modules/dns-firewall-rule-group/variables.tf
+++ b/modules/dns-firewall-rule-group/variables.tf
@@ -124,3 +124,24 @@ variable "resource_group_description" {
   default     = "Managed by Terraform."
   nullable    = false
 }
+
+
+###################################################
+# Resource Sharing by RAM (Resource Access Manager)
+###################################################
+
+variable "shares" {
+  description = "(Optional) A list of resource shares via RAM (Resource Access Manager)."
+  type = list(object({
+    name = optional(string)
+
+    permissions = optional(set(string), ["AWSRAMDefaultPermissionResolverFirewallRuleGroup"])
+
+    external_principals_allowed = optional(bool, false)
+    principals                  = optional(set(string), [])
+
+    tags = optional(map(string), {})
+  }))
+  default  = []
+  nullable = false
+}


### PR DESCRIPTION
### Background

- Support RAM sharing of `dns-firewall-rule-group` module
- Close #11 