### PR TITLE
feat: improve how to use resource_group in modules

### DIFF
--- a/modules/dns-firewall-domain-list/outputs.tf
+++ b/modules/dns-firewall-domain-list/outputs.tf
@@ -17,3 +17,19 @@ output "domains" {
   description = "The list of domains from the firewall domain list."
   value       = aws_route53_resolver_firewall_domain_list.this.domains
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/dns-firewall-domain-list/resource-group.tf
+++ b/modules/dns-firewall-domain-list/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/dns-firewall-domain-list/variables.tf
+++ b/modules/dns-firewall-domain-list/variables.tf
@@ -37,23 +37,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/dns-firewall-rule-group/outputs.tf
+++ b/modules/dns-firewall-rule-group/outputs.tf
@@ -59,3 +59,19 @@ output "sharing" {
     shares = module.share
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/dns-firewall-rule-group/resource-group.tf
+++ b/modules/dns-firewall-rule-group/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/dns-firewall-rule-group/variables.tf
+++ b/modules/dns-firewall-rule-group/variables.tf
@@ -104,26 +104,8 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
-}
 
 
 ###################################################
@@ -143,5 +125,21 @@ variable "shares" {
     tags = optional(map(string), {})
   }))
   default  = []
+  nullable = false
+}
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
   nullable = false
 }

--- a/modules/dns-firewall/outputs.tf
+++ b/modules/dns-firewall/outputs.tf
@@ -31,3 +31,19 @@ output "rule_groups" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/dns-firewall/resource-group.tf
+++ b/modules/dns-firewall/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/dns-firewall/variables.tf
+++ b/modules/dns-firewall/variables.tf
@@ -58,23 +58,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/fms-dns-firewall-policy/outputs.tf
+++ b/modules/fms-dns-firewall-policy/outputs.tf
@@ -41,3 +41,19 @@ output "attributes" {
     cascade_deletion_enabled          = aws_fms_policy.this.delete_all_policy_resources
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/fms-dns-firewall-policy/resource-group.tf
+++ b/modules/fms-dns-firewall-policy/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/fms-dns-firewall-policy/variables.tf
+++ b/modules/fms-dns-firewall-policy/variables.tf
@@ -153,23 +153,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/waf-ip-set/outputs.tf
+++ b/modules/waf-ip-set/outputs.tf
@@ -32,3 +32,19 @@ output "ip_addresses" {
   description = "A list of strings that specify one or more IP addresses or blocks of IP addresses in Classless Inter-Domain Routing (CIDR) notation."
   value       = aws_wafv2_ip_set.this.addresses
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/waf-ip-set/resource-group.tf
+++ b/modules/waf-ip-set/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -13,12 +13,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/waf-ip-set/variables.tf
+++ b/modules/waf-ip-set/variables.tf
@@ -55,23 +55,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }


### PR DESCRIPTION
## Summary
Update resource group configuration to use object-based pattern.

## Changes
- Update module version from ~> 0.10.0 to ~> 0.12.0
- Replace individual resource_group_* variables with single object variable  
- Update all references to use var.resource_group.* structure
- Add resource_group output to each module

## Modules Updated
- dns-firewall
- dns-firewall-domain-list
- dns-firewall-rule-group
- fms-dns-firewall-policy
- waf-ip-set

## Test Plan
- [ ] Review variable changes
- [ ] Verify resource-group module references are correct  
- [ ] Check outputs are properly formatted